### PR TITLE
Use normal multiplication instead of exponentiaion for pow 2 case.

### DIFF
--- a/crop.go
+++ b/crop.go
@@ -168,9 +168,9 @@ func importance(crop *Crop, x, y int) float64 {
 
 	dx := math.Max(px-1.0+edgeRadius, 0.0)
 	dy := math.Max(py-1.0+edgeRadius, 0.0)
-	d := (math.Pow(dx, 2) + math.Pow(dy, 2)) * edgeWeight
+	d := (dx*dx + dy*dy) * edgeWeight
 
-	s := 1.41 - math.Sqrt(math.Pow(px, 2)+math.Pow(py, 2))
+	s := 1.41 - math.Sqrt(px*px+py*py)
 	if ruleOfThirds {
 		s += (math.Max(0.0, s+d+0.5) * 1.2) * (thirds(px) + thirds(py))
 	}
@@ -343,12 +343,12 @@ func skinCol(c color.Color) float64 {
 	g8 := float64(g >> 8)
 	b8 := float64(b >> 8)
 
-	mag := math.Sqrt(math.Pow(r8, 2) + math.Pow(g8, 2) + math.Pow(b8, 2))
+	mag := math.Sqrt(r8*r8 + g8*g8 + b8*b8)
 	rd := r8/mag - skinColor[0]
 	gd := g8/mag - skinColor[1]
 	bd := b8/mag - skinColor[2]
 
-	d := math.Sqrt(math.Pow(rd, 2) + math.Pow(gd, 2) + math.Pow(bd, 2))
+	d := math.Sqrt(rd*rd + gd*gd + bd*bd)
 	return 1.0 - d
 }
 


### PR DESCRIPTION
[`math.Pow` is quite heavy](http://golang.org/src/pkg/math/pow.go?s=1186:1216#L28) and wastes a lot of time while computing the score.
Replacing it by a simple multiplication reduces time by almost 2.

These are the results I got to convert a 598x900 to a 250x250 pixels image with an i7 processor.

With `math.Pow`:

``` sh
$ ./foo 
0.46451133407655143
original resolution: 598x900
scale: 2.392000, cropw: 277.000000, croph: 277.000000, minscale: 0.900000
Time elapsed edge: 48.715635ms
Time elapsed skin: 69.20784ms
Time elapsed sat: 29.168815ms
Time elapsed crops: 57.868us 102
Time elapsed score: 2.086053949s
```

With `x * x`:

``` sh
$ ./foo 
0.46451133407655143
original resolution: 598x900
scale: 2.392000, cropw: 277.000000, croph: 277.000000, minscale: 0.900000
Time elapsed edge: 47.328424ms
Time elapsed skin: 32.094467ms
Time elapsed sat: 29.98ms
Time elapsed crops: 52.197us 102
Time elapsed score: 1.051735309s
```
