### PR TITLE
Decouple the resizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,29 +29,30 @@ To compile it from source:
 package main
 
 import (
-        "fmt"
-        "image"
-        _ "image/png"
-        "os"
+	"fmt"
+	"image"
+	_ "image/png"
+	"os"
 
-        "github.com/muesli/smartcrop"
+	"github.com/muesli/smartcrop"
+	"github.com/muesli/smartcrop/nfnt"
 )
 
 func main() {
-        f, _ := os.Open("image.png")
-        img, _, _ := image.Decode(f)
+	f, _ := os.Open("image.png")
+	img, _, _ := image.Decode(f)
 
-        analyzer := smartcrop.NewAnalyzer()
-        topCrop, _ := analyzer.FindBestCrop(img, 250, 250)
+	analyzer := smartcrop.NewAnalyzer(nfnt.NewDefaultResizer())
+	topCrop, _ := analyzer.FindBestCrop(img, 250, 250)
 
-        // The crop will have the requested aspect ratio, but you need to copy/scale it yourself
-        fmt.Printf("Top crop: %+v\n", topCrop)
+	// The crop will have the requested aspect ratio, but you need to copy/scale it yourself
+	fmt.Printf("Top crop: %+v\n", topCrop)
 
-        type SubImager interface {
-                SubImage(r image.Rectangle) image.Image
-        }
-        croppedimg := img.(SubImager).SubImage(topCrop)
-        ...
+	type SubImager interface {
+		SubImage(r image.Rectangle) image.Image
+	}
+	croppedimg := img.(SubImager).SubImage(topCrop)
+	// ...
 }
 ```
 

--- a/debug.go
+++ b/debug.go
@@ -22,6 +22,7 @@
  *	Authors:
  *		Christian Muehlhaeuser <muesli@gmail.com>
  *		Michael Wendland <michael@michiwend.com>
+ *		Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
  */
 
 /*

--- a/nfnt/resizer.go
+++ b/nfnt/resizer.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2014-2018 Christian Muehlhaeuser
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *	Authors:
+ *		Christian Muehlhaeuser <muesli@gmail.com>
+ *		Michael Wendland <michael@michiwend.com>
+ *		Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
+ */
+
+package nfnt
+
+import (
+	"image"
+
+	"github.com/muesli/smartcrop/options"
+	"github.com/nfnt/resize"
+)
+
+type nfntResizer struct {
+	interpolationType resize.InterpolationFunction
+}
+
+func (r nfntResizer) Resize(img image.Image, width, height uint) image.Image {
+	return resize.Resize(width, height, img, r.interpolationType)
+}
+
+// NewResizer creates a new Resizer with the given interpolation type.
+func NewResizer(interpolationType resize.InterpolationFunction) options.Resizer {
+	return nfntResizer{interpolationType: interpolationType}
+}
+
+// NewDefaultResizer creates a new Resizer with the default interpolation type.
+func NewDefaultResizer() options.Resizer {
+	return NewResizer(resize.Bicubic)
+}

--- a/options/resizer.go
+++ b/options/resizer.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014-2018 Christian Muehlhaeuser
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *	Authors:
+ *		Christian Muehlhaeuser <muesli@gmail.com>
+ *		Michael Wendland <michael@michiwend.com>
+ *		Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
+ */
+
+package options
+
+import (
+	"image"
+)
+
+// Resizer is used to resize images. See the nfnt package for a default implementation using
+// github.com/nfnt/resize.
+type Resizer interface {
+	Resize(img image.Image, width, height uint) image.Image
+}

--- a/smartcrop.go
+++ b/smartcrop.go
@@ -22,6 +22,7 @@
  *	Authors:
  *		Christian Muehlhaeuser <muesli@gmail.com>
  *		Michael Wendland <michael@michiwend.com>
+ *		Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
  */
 
 /*
@@ -39,9 +40,9 @@ import (
 	"math"
 	"time"
 
-	"golang.org/x/image/draw"
+	"github.com/muesli/smartcrop/options"
 
-	"github.com/nfnt/resize"
+	"golang.org/x/image/draw"
 )
 
 var (
@@ -95,33 +96,32 @@ type Crop struct {
 	Score Score
 }
 
-// CropSettings contains options to change cropping behaviour
-type CropSettings struct {
-	InterpolationType resize.InterpolationFunction
-	DebugMode         bool
-	Log               *log.Logger
+// Logger contains a logger.
+type Logger struct {
+	DebugMode bool
+	Log       *log.Logger
 }
 
 type smartcropAnalyzer struct {
-	cropSettings CropSettings
+	logger Logger
+	options.Resizer
 }
 
-// NewAnalyzer returns a new analyzer with default settings
-func NewAnalyzer() Analyzer {
-	cropSettings := CropSettings{
-		InterpolationType: resize.Bicubic,
-		DebugMode:         false,
+// NewAnalyzer returns a new Analyzer using the given Resizer.
+func NewAnalyzer(resizer options.Resizer) Analyzer {
+	logger := Logger{
+		DebugMode: false,
 	}
 
-	return NewAnalyzerWithCropSettings(cropSettings)
+	return NewAnalyzerWithLogger(resizer, logger)
 }
 
-// NewAnalyzerWithCropSettings returns a new analyzer with the given settings
-func NewAnalyzerWithCropSettings(cropSettings CropSettings) Analyzer {
-	if cropSettings.Log == nil {
-		cropSettings.Log = log.New(ioutil.Discard, "", 0)
+// NewAnalyzerWithLogger returns a new analyzer with the given Resizer and Logger.
+func NewAnalyzerWithLogger(resizer options.Resizer, logger Logger) Analyzer {
+	if logger.Log == nil {
+		logger.Log = log.New(ioutil.Discard, "", 0)
 	}
-	return &smartcropAnalyzer{cropSettings: cropSettings}
+	return &smartcropAnalyzer{Resizer: resizer, logger: logger}
 }
 
 func (o smartcropAnalyzer) FindBestCrop(img image.Image, width, height int) (image.Rectangle, error) {
@@ -141,29 +141,29 @@ func (o smartcropAnalyzer) FindBestCrop(img image.Image, width, height int) (ima
 		if f := prescaleMin / math.Min(float64(img.Bounds().Dx()), float64(img.Bounds().Dy())); f < 1.0 {
 			prescalefactor = f
 		}
-		o.cropSettings.Log.Println(prescalefactor)
+		o.logger.Log.Println(prescalefactor)
 
-		smallimg := resize.Resize(
-			uint(float64(img.Bounds().Dx())*prescalefactor),
-			0,
+		smallimg := o.Resize(
 			img,
-			o.cropSettings.InterpolationType)
+			uint(float64(img.Bounds().Dx())*prescalefactor),
+			0)
+
 		lowimg = toRGBA(smallimg)
 	} else {
 		lowimg = toRGBA(img)
 	}
 
-	if o.cropSettings.DebugMode {
+	if o.logger.DebugMode {
 		writeImage("png", lowimg, "./smartcrop_prescale.png")
 	}
 
 	cropWidth, cropHeight := chop(float64(width)*scale*prescalefactor), chop(float64(height)*scale*prescalefactor)
 	realMinScale := math.Min(maxScale, math.Max(1.0/scale, minScale))
 
-	o.cropSettings.Log.Printf("original resolution: %dx%d\n", img.Bounds().Dx(), img.Bounds().Dy())
-	o.cropSettings.Log.Printf("scale: %f, cropw: %f, croph: %f, minscale: %f\n", scale, cropWidth, cropHeight, realMinScale)
+	o.logger.Log.Printf("original resolution: %dx%d\n", img.Bounds().Dx(), img.Bounds().Dy())
+	o.logger.Log.Printf("scale: %f, cropw: %f, croph: %f, minscale: %f\n", scale, cropWidth, cropHeight, realMinScale)
 
-	topCrop, err := analyse(o.cropSettings, lowimg, cropWidth, cropHeight, realMinScale)
+	topCrop, err := analyse(o.logger, lowimg, cropWidth, cropHeight, realMinScale)
 	if err != nil {
 		return topCrop, err
 	}
@@ -249,43 +249,43 @@ func score(output *image.RGBA, crop Crop) Score {
 	return score
 }
 
-func analyse(settings CropSettings, img *image.RGBA, cropWidth, cropHeight, realMinScale float64) (image.Rectangle, error) {
+func analyse(logger Logger, img *image.RGBA, cropWidth, cropHeight, realMinScale float64) (image.Rectangle, error) {
 	o := image.NewRGBA(img.Bounds())
 
 	now := time.Now()
 	edgeDetect(img, o)
-	settings.Log.Println("Time elapsed edge:", time.Since(now))
-	debugOutput(settings.DebugMode, o, "edge")
+	logger.Log.Println("Time elapsed edge:", time.Since(now))
+	debugOutput(logger.DebugMode, o, "edge")
 
 	now = time.Now()
 	skinDetect(img, o)
-	settings.Log.Println("Time elapsed skin:", time.Since(now))
-	debugOutput(settings.DebugMode, o, "skin")
+	logger.Log.Println("Time elapsed skin:", time.Since(now))
+	debugOutput(logger.DebugMode, o, "skin")
 
 	now = time.Now()
 	saturationDetect(img, o)
-	settings.Log.Println("Time elapsed sat:", time.Since(now))
-	debugOutput(settings.DebugMode, o, "saturation")
+	logger.Log.Println("Time elapsed sat:", time.Since(now))
+	debugOutput(logger.DebugMode, o, "saturation")
 
 	now = time.Now()
 	var topCrop Crop
 	topScore := -1.0
 	cs := crops(o, cropWidth, cropHeight, realMinScale)
-	settings.Log.Println("Time elapsed crops:", time.Since(now), len(cs))
+	logger.Log.Println("Time elapsed crops:", time.Since(now), len(cs))
 
 	now = time.Now()
 	for _, crop := range cs {
 		nowIn := time.Now()
 		crop.Score = score(o, crop)
-		settings.Log.Println("Time elapsed single-score:", time.Since(nowIn))
+		logger.Log.Println("Time elapsed single-score:", time.Since(nowIn))
 		if crop.totalScore() > topScore {
 			topCrop = crop
 			topScore = crop.totalScore()
 		}
 	}
-	settings.Log.Println("Time elapsed score:", time.Since(now))
+	logger.Log.Println("Time elapsed score:", time.Since(now))
 
-	if settings.DebugMode {
+	if logger.DebugMode {
 		drawDebugCrop(topCrop, o)
 		debugOutput(true, o, "final")
 	}
@@ -471,12 +471,4 @@ func toRGBA(img image.Image) *image.RGBA {
 	out := image.NewRGBA(img.Bounds())
 	draw.Copy(out, image.Pt(0, 0), img, img.Bounds(), draw.Src, nil)
 	return out
-}
-
-// SmartCrop applies the smartcrop algorithms on the the given image and returns
-// the top crop or an error if something went wrong.
-// This is still here for legacy/backwards-compat reasons
-func SmartCrop(img image.Image, width, height int) (image.Rectangle, error) {
-	analyzer := NewAnalyzer()
-	return analyzer.FindBestCrop(img, width, height)
 }

--- a/smartcrop_test.go
+++ b/smartcrop_test.go
@@ -22,6 +22,7 @@
  *	Authors:
  *		Christian Muehlhaeuser <muesli@gmail.com>
  *		Michael Wendland <michael@michiwend.com>
+ *		Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
  */
 
 package smartcrop
@@ -36,11 +37,19 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/muesli/smartcrop/nfnt"
 )
 
 var (
 	testFile = "./examples/gopher.jpg"
 )
+
+// Moved here and unexported to decouple the resizer implementation.
+func smartCrop(img image.Image, width, height int) (image.Rectangle, error) {
+	analyzer := NewAnalyzer(nfnt.NewDefaultResizer())
+	return analyzer.FindBestCrop(img, width, height)
+}
 
 type SubImager interface {
 	SubImage(r image.Rectangle) image.Image
@@ -55,7 +64,7 @@ func TestCrop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	topCrop, err := SmartCrop(img, 250, 250)
+	topCrop, err := smartCrop(img, 250, 250)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +97,7 @@ func BenchmarkCrop(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := SmartCrop(img, 250, 250); err != nil {
+		if _, err := smartCrop(img, 250, 250); err != nil {
 			b.Error(err)
 		}
 	}
@@ -132,7 +141,7 @@ func BenchmarkImageDir(b *testing.B) {
 				continue
 			}
 
-			topCrop, err := SmartCrop(img, 220, 220)
+			topCrop, err := smartCrop(img, 220, 220)
 			if err != nil {
 				b.Error(err)
 				continue


### PR DESCRIPTION
This commit adds a new `Resizer` interface with the resizer from `nfnt` as the default in its own package.

This allows people to use the smartcrop library with their own resize implemention.

My motivation for this is to use this in Hugo. We use github.com/disintegration/imaging to do image processing -- github.com/nfnt/resize is probably equally good, but imaging had a richer API for the Hugo use cases.

I have tested this library and I'm really impressed by the results (and the speed):

http://hugotest.bep.is/resourcemeta/smartcrop/

The relevant Hugo PR is here:

https://github.com/gohugoio/hugo/pull/4376

I know this is breaking some API, but I think people are happy to adjust as long as it is for a greater good. And this is < 1.0 software, and it is super-easy to upgrade.

Again, tanks for this great piece of software.