### PR TITLE
Update and clarify copyright of example images

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ smartcrop
 smartcrop finds good image crops for arbitrary sizes. It is a pure Go implementation, based on Jonas Wagner's [smartcrop.js](https://github.com/jwagner/smartcrop.js)
 
 ![Example](./examples/gopher.jpg)
-Image: [https://www.flickr.com/photos/usfwspacific/8182486789](https://www.flickr.com/photos/usfwspacific/8182486789) CC BY U.S. Fish & Wildlife
+Image: [https://www.flickr.com/photos/usfwspacific/8182486789](https://www.flickr.com/photos/usfwspacific/8182486789) by Washington Dept of Fish and Wildlife, originally licensed under [CC-BY-2.0](https://creativecommons.org/licenses/by/2.0/) when the image was imported back in September 2014
 
 ![Example](./examples/goodtimes.jpg)
-Image: [https://www.flickr.com/photos/endogamia/5682480447](https://www.flickr.com/photos/endogamia/5682480447) by N. Feans
+Image: [https://www.flickr.com/photos/endogamia/5682480447](https://www.flickr.com/photos/endogamia/5682480447) by Leon F. Cabeiro (N. Feans), licensed under [CC-BY-2.0](https://creativecommons.org/licenses/by/2.0/)
 
 ## Installation
 


### PR DESCRIPTION
examples/goodtimes.jpg is now credited under a different (real?) name on Flickr;

examples/gopher.jpg was relicensed from CC-BY-2.0 to CC-BY-NC-2.0 retrospectively circa November 2016.

(We came across the discrepancies when we were filling out the copyright information for Debian packaging.)

Many thanks!