### PR TITLE
Optional face detection with gocv

### DIFF
--- a/gocv/face.go
+++ b/gocv/face.go
@@ -1,0 +1,62 @@
+package gocv
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"log"
+	"os"
+
+	"github.com/llgcode/draw2d/draw2dimg"
+	"github.com/llgcode/draw2d/draw2dkit"
+)
+
+type FaceDetector struct {
+	FaceDetectionHaarCascadeFilepath string
+	DebugMode                        bool
+}
+
+func (d *FaceDetector) Name() string {
+	return "face"
+}
+
+func (d *FaceDetector) Detect(i *image.RGBA, o *image.RGBA) error {
+	// TODO: Fix to use gocv
+
+	if d.FaceDetectionHaarCascadeFilepath == "" {
+		return fmt.Errorf("FaceDetector's FaceDetectionHaarCascadeFilepath not specified")
+	}
+
+	_, err := os.Stat(d.FaceDetectionHaarCascadeFilepath)
+	if err != nil {
+		return err
+	}
+	cascade := opencv.LoadHaarClassifierCascade(d.FaceDetectionHaarCascadeFilepath)
+	defer cascade.Release()
+
+	cvImage := opencv.FromImage(i)
+	defer cvImage.Release()
+
+	faces := cascade.DetectObjects(cvImage)
+
+	gc := draw2dimg.NewGraphicContext(o)
+
+	if d.DebugMode == true {
+		log.Println("Faces detected:", len(faces))
+	}
+
+	for _, face := range faces {
+		if d.DebugMode == true {
+			log.Printf("Face: x: %d y: %d w: %d h: %d\n", face.X(), face.Y(), face.Width(), face.Height())
+		}
+		draw2dkit.Ellipse(
+			gc,
+			float64(face.X()+(face.Width()/2)),
+			float64(face.Y()+(face.Height()/2)),
+			float64(face.Width()/2),
+			float64(face.Height())/2)
+		gc.SetFillColor(color.RGBA{255, 0, 0, 255})
+		gc.Fill()
+	}
+	return nil
+}

--- a/nfnt/resizer.go
+++ b/nfnt/resizer.go
@@ -30,8 +30,8 @@ package nfnt
 import (
 	"image"
 
+	"github.com/muesli/smartcrop/options"
 	"github.com/nfnt/resize"
-	"github.com/svkoskin/smartcrop/options"
 )
 
 type nfntResizer struct {

--- a/nfnt/resizer.go
+++ b/nfnt/resizer.go
@@ -30,8 +30,8 @@ package nfnt
 import (
 	"image"
 
-	"github.com/muesli/smartcrop/options"
 	"github.com/nfnt/resize"
+	"github.com/svkoskin/smartcrop/options"
 )
 
 type nfntResizer struct {

--- a/smartcrop-rundebug/main.go
+++ b/smartcrop-rundebug/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/svkoskin/smartcrop"
 	"github.com/svkoskin/smartcrop/nfnt"
+	//	"github.com/svkoskin/smartcrop/gocv"
 )
 
 func main() {
@@ -27,6 +28,17 @@ func main() {
 	}
 
 	analyzer := smartcrop.NewAnalyzerWithLogger(nfnt.NewDefaultResizer(), l)
+
+	/*
+		To replace skin detection with gocv-based face detection:
+
+		analyzer.SetDetectors([]smartcrop.Detector{
+			&smartcrop.EdgeDetector{},
+			&gocv.FaceDetector{"./cascade.xml", true},
+			&smartcrop.SaturationDetector{},
+		})
+	*/
+
 	topCrop, _ := analyzer.FindBestCrop(img, 300, 200)
 
 	// The crop will have the requested aspect ratio, but you need to copy/scale it yourself

--- a/smartcrop-rundebug/main.go
+++ b/smartcrop-rundebug/main.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/svkoskin/smartcrop"
-	"github.com/svkoskin/smartcrop/nfnt"
-	//	"github.com/svkoskin/smartcrop/gocv"
+	"github.com/muesli/smartcrop"
+	//	"github.com/muesli/smartcrop/gocv"
+	"github.com/muesli/smartcrop/nfnt"
 )
 
 func main() {

--- a/smartcrop-rundebug/main.go
+++ b/smartcrop-rundebug/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"log"
+	"os"
+
+	"github.com/svkoskin/smartcrop"
+	"github.com/svkoskin/smartcrop/nfnt"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Please give me an argument")
+		os.Exit(1)
+	}
+
+	f, _ := os.Open(os.Args[1])
+	img, _, _ := image.Decode(f)
+
+	l := smartcrop.Logger{
+		DebugMode: true,
+		Log:       log.New(os.Stderr, "", 0),
+	}
+
+	analyzer := smartcrop.NewAnalyzerWithLogger(nfnt.NewDefaultResizer(), l)
+	topCrop, _ := analyzer.FindBestCrop(img, 300, 200)
+
+	// The crop will have the requested aspect ratio, but you need to copy/scale it yourself
+	fmt.Printf("Top crop: %+v\n", topCrop)
+}

--- a/smartcrop.go
+++ b/smartcrop.go
@@ -40,7 +40,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/svkoskin/smartcrop/options"
+	"github.com/muesli/smartcrop/options"
 
 	"golang.org/x/image/draw"
 )

--- a/smartcrop.go
+++ b/smartcrop.go
@@ -54,7 +54,7 @@ var (
 
 const (
 	detailWeight            = 0.2
-	skinBias                = 0.01
+	skinBias                = 0.9
 	skinBrightnessMin       = 0.2
 	skinBrightnessMax       = 1.0
 	skinThreshold           = 0.8

--- a/smartcrop.go
+++ b/smartcrop.go
@@ -40,7 +40,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/muesli/smartcrop/options"
+	"github.com/svkoskin/smartcrop/options"
 
 	"golang.org/x/image/draw"
 )

--- a/smartcrop_test.go
+++ b/smartcrop_test.go
@@ -38,7 +38,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/muesli/smartcrop/nfnt"
+	"github.com/svkoskin/smartcrop/nfnt"
 )
 
 var (

--- a/smartcrop_test.go
+++ b/smartcrop_test.go
@@ -38,7 +38,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/svkoskin/smartcrop/nfnt"
+	"github.com/muesli/smartcrop/nfnt"
 )
 
 var (

--- a/smartcrop_test.go
+++ b/smartcrop_test.go
@@ -118,8 +118,9 @@ func BenchmarkEdge(b *testing.B) {
 	rgbaImg := toRGBA(img)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		d := EdgeDetector{}
 		o := image.NewRGBA(img.Bounds())
-		edgeDetect(rgbaImg, o)
+		d.Detect(rgbaImg, o)
 	}
 }
 


### PR DESCRIPTION
I restored face detection features using another set of bindings for OpenCV, called gocv. It should still be possible to build smartcrop without having OpenCV installed. I have no particular interest in maintaining or supporting a fork, so if there is any chance for this to get merged, I'd appreciate it 😸 